### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,3 @@
-###__Greatness from Basis comes__    
+### __Greatness from Basis comes__    
 Finished 214/374       
 Reetsee.Xu last updated on 2016.09.04               


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
